### PR TITLE
Made open() await-able, fixing exception-catching

### DIFF
--- a/lib/src/serial_port.dart
+++ b/lib/src/serial_port.dart
@@ -195,7 +195,7 @@ class SerialPort {
   }
 
   /// [open] can be called when handler is null or handler is closed
-  void open() async {
+  Future<void> open() async {
     /// Do not open a port which has been opened
     if (isOpened == false) {
       handler = CreateFile(


### PR DESCRIPTION
Because the `open()` method returned `void` and not `Future<void>` but is marked async, the thrown Exceptions when the port cannot be opened can not be handled by a try-block. This happens because I cannot mark the function call with `await`, so it will always get executed asynchronously, and the exception is thrown when the calling code is already ahead.